### PR TITLE
Add the ability to detect PowerUp - Invoke-AllChecks

### DIFF
--- a/rules/windows/powershell/powershell_malicious_commandlets.yml
+++ b/rules/windows/powershell/powershell_malicious_commandlets.yml
@@ -110,6 +110,7 @@ detection:
             - "*Invoke-ReverseDNSLookup*"
             - "*Invoke-SMBScanner*"
             - "*Invoke-Mimikittenz*"
+            - "*Invoke-AllChecks*"
     false_positives:
         - Get-SystemDriveInfo  # http://bheltborg.dk/Windows/WinSxS/amd64_microsoft-windows-maintenancediagnostic_31bf3856ad364e35_10.0.10240.16384_none_91ef7543a4514b5e/CL_Utility.ps1
     condition: keywords and not false_positives


### PR DESCRIPTION
PowerUp allow attackers to check if is possible to have a local privilege escalation attacks against Windows systems. The main function is called "Invoke-AllChecks" and check possible path of escalation.